### PR TITLE
More descriptive versioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  */
 
 group 'baritone'
-version '1.2.15'
+version = getGitCommit()
 
 buildscript {
     repositories {
@@ -143,6 +143,33 @@ task proguard(type: ProguardTask) {
 }
 
 task createDist(type: CreateDistTask, dependsOn: proguard)
+
+def getGitCommit() {
+    def projectDirFile = new File("$projectDir")
+    def dotGit = new File(projectDirFile, ".git")
+    if (!dotGit.isDirectory()) return 'non-git build'
+
+    def cmd = 'git describe --always --tags --dirty=+'
+    def proc = cmd.execute(null, projectDirFile)
+    proc.waitForOrKill(10 * 1000)
+
+    def gitCommit = proc.text.trim().substring(1) // remove the 'v' prefix
+    assert !gitCommit.isEmpty()
+
+    def srCmd = 'git symbolic-ref --short HEAD' // find branch name
+    def srProc = srCmd.execute(null, projectDirFile)
+    srProc.waitForOrKill(10 * 1000)
+    if (srProc.exitValue() == 0) {
+        // Only add the information if the git command was
+        // successful. There may be no symbolic reference for HEAD if
+        // e.g. in detached mode.
+        def symbolicReference = srProc.text.trim()
+        assert !symbolicReference.isEmpty()
+        gitCommit += "-$symbolicReference"
+    }
+
+    gitCommit
+}
 
 build.finalizedBy(createDist)
 


### PR DESCRIPTION
 At the moment all your releases are named 1.2.15. To better differentiate between your releases I'm proposing a more descriptive versioning. Use the 'git describe' command to give a more accurate version.
    
Example version:  `1.2.15-23-g629cf53c-highwayBuilding`
    
```
     1.2.15  - is the parent branch or release your code is based on
     23       - is the number of commits since v1.12.15
     g        - specifics that the SCM is Git
     629cf53c - is the abbreviated SHA1 when the release/build was made
     <branch name> - lastly, the branch name gets appended
```

The JARs will be named appropriately too, thus allowing for multiple versions in case the lastest version has a critical last minute bug etc.. The JARs will be named as follows:

```
baritone-api-forge-1.2.15-24-ga08f658f-highwayBuilding-graemeg.jar
```

And in Minecraft the reported Baritone version will also be shown:
![Screenshot at 2021-05-25 22-06-22](https://user-images.githubusercontent.com/72053/119572701-11c34800-bdab-11eb-9848-1f56089101e0.png)
